### PR TITLE
Include examples in command descriptor

### DIFF
--- a/src/__tests__/usage.test.js
+++ b/src/__tests__/usage.test.js
@@ -62,24 +62,6 @@ describe(testContext(__filename), function () {
     })
   })
 
-  describe('exampleList', function () {
-    it('returns empty string if there are no examples', function () {
-      expect(exampleList(undefined)).to.equal('')
-      expect(exampleList(null)).to.equal('')
-      expect(exampleList([])).to.equal('')
-    })
-
-    it('returns examples with their descriptions', function () {
-      const lines = exampleList(this.commandDescriptor.examples).split('\n').filter(line => line.length > 0)
-
-      expect(lines[0]).to.match(/Examples:/)
-      expect(lines[1]).to.match(/\/\/.+run command 1 with flag/)
-      expect(lines[2]).to.match(/cmd1 -f/)
-      expect(lines[3]).to.match(/\/\/.+run command 2 with arguments/)
-      expect(lines[4]).to.match(/cmd2 foo bar/)
-    })
-  })
-
   describe('commandList', function () {
     it('returns empty string if there are no commands', function () {
       expect(commandList(undefined)).to.equal('')
@@ -110,16 +92,34 @@ describe(testContext(__filename), function () {
     })
   })
 
+  describe('exampleList', function () {
+    it('returns empty string if there are no examples', function () {
+      expect(exampleList(undefined)).to.equal('')
+      expect(exampleList(null)).to.equal('')
+      expect(exampleList([])).to.equal('')
+    })
+
+    it('returns examples with their descriptions', function () {
+      const lines = exampleList(this.commandDescriptor.examples).split('\n').filter(line => line.length > 0)
+
+      expect(lines[0]).to.match(/Examples:/)
+      expect(lines[1]).to.match(/\/\/.+run command 1 with flag/)
+      expect(lines[2]).to.match(/cmd1 -f/)
+      expect(lines[3]).to.match(/\/\/.+run command 2 with arguments/)
+      expect(lines[4]).to.match(/cmd2 foo bar/)
+    })
+  })
+
   describe('usageMessage', function () {
     it('returns the full usage for the command', function () {
       const lines = usageMessage(this.commandDescriptor).split('\n').filter(line => line.length > 0)
       expect(lines[0]).to.equal(`${this.commandDescriptor.name} - ${this.commandDescriptor.description}`)
       expect(lines.length).to.equal(
-        1 +                                            // name + description
-        5 +                                            // Examples: and example list
-        2 +                                            // Usage: and usage line
-        this.commandDescriptor.commands.length + 1 +   // Commands: and command list
-        this.commandDescriptor.options.length + 1      // Options: and option list
+        1 +                                             // name + description
+        2 +                                             // Usage: and usage line
+        this.commandDescriptor.commands.length + 1 +    // Commands: and command list
+        this.commandDescriptor.options.length + 1 +     // Options: and option list
+        (this.commandDescriptor.examples.length * 2) + 1 // Examples: and example list
       )
     })
 
@@ -147,7 +147,6 @@ describe(testContext(__filename), function () {
     it('returns the parent command usage when "--help" was requested on parent command', function () {
       const args = {_: [], help: true}
       const usageString = usage(this.commandDescriptor, args, {includeHelp: true})
-      console.log(usageString)
       expect(usageString).to.match(/^cmd -/)
     })
 

--- a/src/__tests__/usage.test.js
+++ b/src/__tests__/usage.test.js
@@ -103,9 +103,9 @@ describe(testContext(__filename), function () {
       const lines = exampleList(this.commandDescriptor.examples).split('\n').filter(line => line.length > 0)
 
       expect(lines[0]).to.match(/Examples:/)
-      expect(lines[1]).to.match(/\/\/.+run command 1 with flag/)
+      expect(lines[1]).to.match(/#.+run command 1 with flag/)
       expect(lines[2]).to.match(/cmd1 -f/)
-      expect(lines[3]).to.match(/\/\/.+run command 2 with arguments/)
+      expect(lines[3]).to.match(/#.+run command 2 with arguments/)
       expect(lines[4]).to.match(/cmd2 foo bar/)
     })
   })

--- a/src/__tests__/usage.test.js
+++ b/src/__tests__/usage.test.js
@@ -2,7 +2,7 @@
 /* global expect, testContext */
 /* eslint-disable prefer-arrow-callback, no-unused-expressions */
 
-import usage, {usageInfo, commandList, optionList, usageMessage} from '../usage'
+import usage, {usageInfo, exampleList, commandList, optionList, usageMessage} from '../usage'
 
 function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
@@ -14,6 +14,13 @@ describe(testContext(__filename), function () {
       name: 'cmd',
       description: 'test command',
       usage: 'cmd [options] <argument>',
+      examples: [{
+        example: 'cmd1 -f',
+        description: 'run command 1 with flag'
+      }, {
+        example: 'cmd2 foo bar',
+        description: 'run command 2 with arguments'
+      }],
       commands: [{
         name: 'cmd1',
         description: 'desc1',
@@ -55,6 +62,24 @@ describe(testContext(__filename), function () {
     })
   })
 
+  describe('exampleList', function () {
+    it('returns empty string if there are no examples', function () {
+      expect(exampleList(undefined)).to.equal('')
+      expect(exampleList(null)).to.equal('')
+      expect(exampleList([])).to.equal('')
+    })
+
+    it('returns examples with their descriptions', function () {
+      const lines = exampleList(this.commandDescriptor.examples).split('\n').filter(line => line.length > 0)
+
+      expect(lines[0]).to.match(/Examples:/)
+      expect(lines[1]).to.match(/\/\/.+run command 1 with flag/)
+      expect(lines[2]).to.match(/cmd1 -f/)
+      expect(lines[3]).to.match(/\/\/.+run command 2 with arguments/)
+      expect(lines[4]).to.match(/cmd2 foo bar/)
+    })
+  })
+
   describe('commandList', function () {
     it('returns empty string if there are no commands', function () {
       expect(commandList(undefined)).to.equal('')
@@ -91,6 +116,7 @@ describe(testContext(__filename), function () {
       expect(lines[0]).to.equal(`${this.commandDescriptor.name} - ${this.commandDescriptor.description}`)
       expect(lines.length).to.equal(
         1 +                                            // name + description
+        5 +                                            // Examples: and example list
         2 +                                            // Usage: and usage line
         this.commandDescriptor.commands.length + 1 +   // Commands: and command list
         this.commandDescriptor.options.length + 1      // Options: and option list
@@ -121,6 +147,7 @@ describe(testContext(__filename), function () {
     it('returns the parent command usage when "--help" was requested on parent command', function () {
       const args = {_: [], help: true}
       const usageString = usage(this.commandDescriptor, args, {includeHelp: true})
+      console.log(usageString)
       expect(usageString).to.match(/^cmd -/)
     })
 

--- a/src/__tests__/usage.test.js
+++ b/src/__tests__/usage.test.js
@@ -15,19 +15,27 @@ describe(testContext(__filename), function () {
       description: 'test command',
       usage: 'cmd [options] <argument>',
       examples: [{
-        example: 'cmd1 -f',
-        description: 'run command 1 with flag'
+        example: 'cmd --second',
+        description: 'run command with second option'
       }, {
-        example: 'cmd2 foo bar',
-        description: 'run command 2 with arguments'
+        example: 'cmd foo bar',
+        description: 'run command with arguments'
       }],
       commands: [{
         name: 'cmd1',
         description: 'desc1',
         usage: 'cmd1 <arg>',
+        examples: [{
+          example: 'cmd cmd1',
+          description: 'run command 1'
+        }],
       }, {
         name: 'cmd2',
         description: 'desc2',
+        examples: [{
+          example: 'cmd cmd2 foo bar',
+          description: 'run command 2 with arguments'
+        }],
       }],
       options: [{
         name: 'first',
@@ -103,10 +111,10 @@ describe(testContext(__filename), function () {
       const lines = exampleList(this.commandDescriptor.examples).split('\n').filter(line => line.length > 0)
 
       expect(lines[0]).to.match(/Examples:/)
-      expect(lines[1]).to.match(/#.+run command 1 with flag/)
-      expect(lines[2]).to.match(/cmd1 -f/)
-      expect(lines[3]).to.match(/#.+run command 2 with arguments/)
-      expect(lines[4]).to.match(/cmd2 foo bar/)
+      expect(lines[1]).to.match(/#.+run command with second option/)
+      expect(lines[2]).to.match(/cmd --second/)
+      expect(lines[3]).to.match(/#.+run command with arguments/)
+      expect(lines[4]).to.match(/cmd foo bar/)
     })
   })
 

--- a/src/usage.js
+++ b/src/usage.js
@@ -14,6 +14,17 @@ export function usageInfo(usage, parentCommand = null) {
   return `\nUsage:\n    ${usageString}`
 }
 
+export function exampleList(examples) {
+  if (!examples || examples.length === 0) {
+    return ''
+  }
+
+  const exampleDescs = examples.map(expl => (
+    sprintf(`    // %s\n    %s`, expl.description, expl.example)
+  ))
+  return `\nExamples:\n${exampleDescs.join('\n')}\n`
+}
+
 export function commandList(commands) {
   if (!commands || commands.length === 0) {
     return ''
@@ -49,6 +60,7 @@ export function usageMessage(commandDescriptor, parentCommand = null) {
   const fullCommandName = parentCommand ? `${parentCommand} ${commandDescriptor.name}` : commandDescriptor.name
   return `${fullCommandName} - ${commandDescriptor.description}
 ${usageInfo(commandDescriptor.usage || commandDescriptor.name, parentCommand)}
+${exampleList(commandDescriptor.examples)}
 ${commandList(commandDescriptor.commands)}
 ${optionList(commandDescriptor.options)}`
 }

--- a/src/usage.js
+++ b/src/usage.js
@@ -43,7 +43,7 @@ export function exampleList(examples) {
   }
 
   const exampleDescs = examples.map(expl => (
-    sprintf(`    // %s\n    %s\n`, expl.description, expl.example)
+    sprintf(`    # %s\n    %s\n`, expl.description, expl.example)
   ))
   return `Examples:\n${exampleDescs.join('\n')}`
 }

--- a/src/usage.js
+++ b/src/usage.js
@@ -14,17 +14,6 @@ export function usageInfo(usage, parentCommand = null) {
   return `\nUsage:\n    ${usageString}`
 }
 
-export function exampleList(examples) {
-  if (!examples || examples.length === 0) {
-    return ''
-  }
-
-  const exampleDescs = examples.map(expl => (
-    sprintf(`    // %s\n    %s`, expl.description, expl.example)
-  ))
-  return `\nExamples:\n${exampleDescs.join('\n')}\n`
-}
-
 export function commandList(commands) {
   if (!commands || commands.length === 0) {
     return ''
@@ -36,7 +25,7 @@ export function commandList(commands) {
   const commandDescs = commands.map(cmd => (
     sprintf(`    %-${maxCommandWidth}s - %s`, cmd.name, cmd.description)
   ))
-  return `\nCommands:\n${commandDescs.join('\n')}\n`
+  return `\nCommands:\n${commandDescs.join('\n')}`
 }
 
 export function optionList(options) {
@@ -45,7 +34,18 @@ export function optionList(options) {
   }
 
   const cliOpts = cliclopts(options)
-  return `Options:\n${cliOpts.usage()}`
+  return `\nOptions:\n${cliOpts.usage()}`
+}
+
+export function exampleList(examples) {
+  if (!examples || examples.length === 0) {
+    return ''
+  }
+
+  const exampleDescs = examples.map(expl => (
+    sprintf(`    // %s\n    %s\n`, expl.description, expl.example)
+  ))
+  return `Examples:\n${exampleDescs.join('\n')}`
 }
 
 function commandDescriptorIncludesDefaultHelp(commandDescriptor) {
@@ -60,9 +60,9 @@ export function usageMessage(commandDescriptor, parentCommand = null) {
   const fullCommandName = parentCommand ? `${parentCommand} ${commandDescriptor.name}` : commandDescriptor.name
   return `${fullCommandName} - ${commandDescriptor.description}
 ${usageInfo(commandDescriptor.usage || commandDescriptor.name, parentCommand)}
-${exampleList(commandDescriptor.examples)}
 ${commandList(commandDescriptor.commands)}
-${optionList(commandDescriptor.options)}`
+${optionList(commandDescriptor.options)}
+${exampleList(commandDescriptor.examples)}`
 }
 
 export default function usage(cd, args = null, options = DEFAULT_OPTIONS) {


### PR DESCRIPTION
For supporting https://github.com/LearnersGuild/game-cli/issues/6

New output:

```
cmd - test command

Usage:
    cmd [options] <argument>

Commands:
    cmd1 - desc1
    cmd2 - desc2

Options:
    --first, -f           first option
    --second, -s          second option
    --help, -h            print usage information

Examples:
    // run command 1 with flag
    cmd1 -f

    // run command 2 with arguments
    cmd2 foo bar
```
